### PR TITLE
Add notes to calculate_mean_and_stdv for empty input handling

### DIFF
--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -115,7 +115,14 @@ def calculate_mean_and_stdv(values_list, round_decimals=0):
     -------
     tuple of (float, float)
         Mean and standard deviation of the input list.
+
+    Notes
+    -----
+    Returns (0, 0) when:
+        - The input list is empty
+        - After filtering out None values, no elements remain
     """
+
     filtered_list = [x for x in values_list if x is not None]
 
     if not filtered_list:

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -119,8 +119,8 @@ def calculate_mean_and_stdv(values_list, round_decimals=0):
     Notes
     -----
     Returns (0, 0) when:
-        - The input list is empty
-        - After filtering out None values, no elements remain
+        - The input list is empty.
+        - After filtering out None values, no elements remain.
     """
 
     filtered_list = [x for x in values_list if x is not None]


### PR DESCRIPTION
Clarify the behavior of the function when the input list is empty or contains only None values, specifying that it returns (0, 0).

Fixes #57 