### PR TITLE
Changes to bioformats module's metadata retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ As this is a major release, not all changes and functions are listed below. For 
 
 * `imcflibs.pathtools.create_directory` to create a new directory at the specified path.
 
+* Additions to `imcflibs.imagej.bioformats`:
+  * `imcflibs.imagej.bioformats.export` to export an image to a given file.
+  * `imcflibs.imagej.bioformats.get_metadata_from_file` to extract various metadata from a given file using BioFormats.
+  * `imcflibs.imagej.bioformats.get_stage_coords`to get stage coordinates and calibration for one or more given images.
+
 ## 1.4.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,10 @@ As this is a major release, not all changes and functions are listed below. For 
 
 * Additions to `imcflibs.imagej.bioformats`:
   * `imcflibs.imagej.bioformats.export` to export an image to a given file.
-  * `imcflibs.imagej.bioformats.get_metadata_from_file` to extract various metadata from a given file using BioFormats.
-  * `imcflibs.imagej.bioformats.get_stage_coords`to get stage coordinates and calibration for one or more given images.
+  * `imcflibs.imagej.bioformats.get_metadata_from_file` to extract various
+    metadata from a given file using BioFormats.
+  * `imcflibs.imagej.bioformats.get_stage_coords`to get stage coordinates and
+    calibration for one or more given images.
 
 ## 1.4.0
 

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -464,9 +464,9 @@ def get_metadata_from_file(path_to_image):
     reader.setId(str(path_to_image))
 
     metadata = ImageMetadata(
-        unit_width=ome_meta.getPixelsPhysicalSizeX(0),
-        unit_height=ome_meta.getPixelsPhysicalSizeY(0),
-        unit_depth=ome_meta.getPixelsPhysicalSizeZ(0),
+        unit_width=ome_meta.getPixelsPhysicalSizeX(0).value(),
+        unit_height=ome_meta.getPixelsPhysicalSizeY(0).value(),
+        unit_depth=ome_meta.getPixelsPhysicalSizeZ(0).value(),
         unit=ome_meta.getPixelsPhysicalSizeX(0).unit().symbol,
         pixel_width=ome_meta.getPixelsSizeX(0),
         pixel_height=ome_meta.getPixelsSizeY(0),

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -110,7 +110,7 @@ class ImageMetadata(object):
         )
 
 
-class StageMetadata:
+class StageMetadata(object):
     """A class to store stage coordinates and calibration metadata for a set of images.
 
     Attributes
@@ -171,10 +171,9 @@ class StageMetadata:
 
     def __repr__(self):
         """Return a string representation of the object."""
-        return "<StageMetadata(dimensions={}, calibration_unit='{}', ...)>".format(
-            self.dimensions, self.calibration_unit
+        return "<StageMetadata({})>".format(
+            ", ".join("{}={}".format(k, v) for k, v in self.__dict__.items())
         )
-
 
 def import_image(
     filename,
@@ -467,6 +466,7 @@ def get_metadata_from_file(path_to_image):
         unit_width=ome_meta.getPixelsPhysicalSizeX(0),
         unit_height=ome_meta.getPixelsPhysicalSizeY(0),
         unit_depth=ome_meta.getPixelsPhysicalSizeZ(0),
+        unit=ome_meta.getPixelsPhysicalSizeX(0).unit().symbol,
         pixel_width=ome_meta.getPixelsSizeX(0),
         pixel_height=ome_meta.getPixelsSizeY(0),
         slice_count=ome_meta.getPixelsSizeZ(0),
@@ -562,9 +562,12 @@ def get_stage_coords(filenames):
             else:
                 series_names.append(str(image))
 
-            current_position_x = getattr(ome_meta.getPlanePositionX(series, 0), "value", lambda: 0)()
-            current_position_y = getattr(ome_meta.getPlanePositionY(series, 0), "value", lambda: 0)()
-            current_position_z = getattr(ome_meta.getPlanePositionZ(series, 0), "value", lambda: 1.0)()
+            current_position_x = getattr(ome_meta.getPlanePositionX(series, 0), "value",
+                                         lambda: 0)()
+            current_position_y = getattr(ome_meta.getPlanePositionY(series, 0), "value",
+                                         lambda: 0)()
+            current_position_z = getattr(ome_meta.getPlanePositionZ(series, 0), "value",
+                                         lambda: 1.0)()
 
             max_phys_size_x = max(max_phys_size_x, ome_meta.getPixelsPhysicalSizeX(series).value())
             max_phys_size_y = max(max_phys_size_y, ome_meta.getPixelsPhysicalSizeY(series).value())

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -480,15 +480,13 @@ def get_metadata_from_file(path_to_image):
     return metadata
 
 
-def get_stage_coords(source, filenames):
+def get_stage_coords(filenames):
     """Get stage coordinates and calibration for a given list of images.
 
     Parameters
     ----------
-    source : str
-        Path to the images.
     filenames : list of str
-        List of image filenames.
+        List of image filepaths.
 
     Returns
     -------
@@ -518,7 +516,7 @@ def get_stage_coords(source, filenames):
         reader.setFlattenedResolutions(False)
         ome_meta = MetadataTools.createOMEXMLMetadata()
         reader.setMetadataStore(ome_meta)
-        reader.setId(source + str(image))
+        reader.setId(str(image))
         series_count = reader.getSeriesCount()
 
         # Process only the first image to get values not dependent on series

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -72,6 +72,7 @@ class ImageMetadata(object):
         unit_width=None,
         unit_height=None,
         unit_depth=None,
+        unit=None,
         pixel_width=None,
         pixel_height=None,
         slice_count=None,
@@ -83,6 +84,7 @@ class ImageMetadata(object):
         self.unit_width = unit_width
         self.unit_height = unit_height
         self.unit_depth = unit_depth
+        self.unit = unit
         self.pixel_width = pixel_width
         self.pixel_height = pixel_height
         self.slice_count = slice_count

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -452,54 +452,30 @@ def get_metadata_from_file(path_to_image):
 
     Returns
     -------
-    dict
-        A dictionary containing the following metadata:
-
-            {
-                unit_width : float,  # physical width of a pixel
-                unit_height : float,  # physical height of a pixel
-                unit_depth : float,  # physical depth of a voxel
-                pixel_width : int,  # width of the image in pixels
-                pixel_height : int,  # height of the image in pixels
-                slice_count : int,  # number of Z-slices
-                channel_count : int,  # number of channels
-                timepoints_count : int,  # number of timepoints
-                dimension_order : str,  # order of dimensions, e.g. "XYZCT"
-                pixel_type : str,  # data type of the pixel values
-            }
+    ImageMetadata
+        An instance of `imcflibs.imagej.bioformats.ImageMetadata` containing the extracted metadata.
     """
+
     reader = ImageReader()
     ome_meta = MetadataTools.createOMEXMLMetadata()
     reader.setMetadataStore(ome_meta)
     reader.setId(str(path_to_image))
 
-    phys_size_x = ome_meta.getPixelsPhysicalSizeX(0)
-    phys_size_y = ome_meta.getPixelsPhysicalSizeY(0)
-    phys_size_z = ome_meta.getPixelsPhysicalSizeZ(0)
-    pixel_size_x = ome_meta.getPixelsSizeX(0)
-    pixel_size_y = ome_meta.getPixelsSizeY(0)
-    pixel_size_z = ome_meta.getPixelsSizeZ(0)
-    channel_count = ome_meta.getPixelsSizeC(0)
-    timepoints_count = ome_meta.getPixelsSizeT(0)
-    dimension_order = ome_meta.getPixelsDimensionOrder(0)
-    pixel_type = ome_meta.getPixelsType(0)
-
-    image_calibration = {
-        "unit_width": phys_size_x.value(),
-        "unit_height": phys_size_y.value(),
-        "unit_depth": phys_size_z.value(),
-        "pixel_width": pixel_size_x.getNumberValue(),
-        "pixel_height": pixel_size_y.getNumberValue(),
-        "slice_count": pixel_size_z.getNumberValue(),
-        "channel_count": channel_count.getNumberValue(),
-        "timepoints_count": timepoints_count.getNumberValue(),
-        "dimension_order": dimension_order,
-        "pixel_type": pixel_type,
-    }
-
+    metadata = ImageMetadata(
+        unit_width=ome_meta.getPixelsPhysicalSizeX(0),
+        unit_height=ome_meta.getPixelsPhysicalSizeY(0),
+        unit_depth=ome_meta.getPixelsPhysicalSizeZ(0),
+        pixel_width=ome_meta.getPixelsSizeX(0),
+        pixel_height=ome_meta.getPixelsSizeY(0),
+        slice_count=ome_meta.getPixelsSizeZ(0),
+        channel_count=ome_meta.getPixelsSizeC(0),
+        timepoints_count=ome_meta.getPixelsSizeT(0),
+        dimension_order=ome_meta.getPixelsDimensionOrder(0),
+        pixel_type=ome_meta.getPixelsType(0),
+    )
     reader.close()
 
-    return image_calibration
+    return metadata
 
 
 def get_stage_coords(source, filenames):

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -175,6 +175,7 @@ class StageMetadata(object):
             ", ".join("{}={}".format(k, v) for k, v in self.__dict__.items())
         )
 
+
 def import_image(
     filename,
     color_mode="color",
@@ -530,22 +531,36 @@ def get_stage_coords(filenames):
             dimensions = 2 if frame_size_z == 1 else 3
 
             # Retrieve physical size coordinates safely
-            phys_size_x = getattr(ome_meta.getPixelsPhysicalSizeX(0), "value", lambda: 1.0)()
-            phys_size_y = getattr(ome_meta.getPixelsPhysicalSizeY(0), "value", lambda: 1.0)()
-            phys_size_z = getattr(ome_meta.getPixelsPhysicalSizeZ(0), "value", lambda: None)()
+            phys_size_x = getattr(
+                ome_meta.getPixelsPhysicalSizeX(0), "value", lambda: 1.0
+            )()
+            phys_size_y = getattr(
+                ome_meta.getPixelsPhysicalSizeY(0), "value", lambda: 1.0
+            )()
+            phys_size_z = getattr(
+                ome_meta.getPixelsPhysicalSizeZ(0), "value", lambda: None
+            )()
 
             z_interval = phys_size_z if phys_size_z is not None else 1.0
 
             # Handle missing Z calibration
             if phys_size_z is None and frame_size_z > 1:
-                first_plane = getattr(ome_meta.getPlanePositionZ(0, 0), "value", lambda: 0)()
+                first_plane = getattr(
+                    ome_meta.getPlanePositionZ(0, 0), "value", lambda: 0
+                )()
                 next_plane_index = frame_size_c + frame_size_t - 1
-                second_plane = getattr(ome_meta.getPlanePositionZ(0, next_plane_index), "value", lambda: 0)()
+                second_plane = getattr(
+                    ome_meta.getPlanePositionZ(0, next_plane_index), "value", lambda: 0
+                )()
                 z_interval = abs(first_plane - second_plane)
 
             image_calibration = [phys_size_x, phys_size_y, z_interval]
             calibration_unit = (
-                getattr(ome_meta.getPixelsPhysicalSizeX(0).unit(), "getSymbol", lambda: "unknown")()
+                getattr(
+                    ome_meta.getPixelsPhysicalSizeX(0).unit(),
+                    "getSymbol",
+                    lambda: "unknown",
+                )()
                 if phys_size_x
                 else "unknown"
             )
@@ -562,17 +577,28 @@ def get_stage_coords(filenames):
             else:
                 series_names.append(str(image))
 
-            current_position_x = getattr(ome_meta.getPlanePositionX(series, 0), "value",
-                                         lambda: 0)()
-            current_position_y = getattr(ome_meta.getPlanePositionY(series, 0), "value",
-                                         lambda: 0)()
-            current_position_z = getattr(ome_meta.getPlanePositionZ(series, 0), "value",
-                                         lambda: 1.0)()
+            current_position_x = getattr(
+                ome_meta.getPlanePositionX(series, 0), "value", lambda: 0
+            )()
+            current_position_y = getattr(
+                ome_meta.getPlanePositionY(series, 0), "value", lambda: 0
+            )()
+            current_position_z = getattr(
+                ome_meta.getPlanePositionZ(series, 0), "value", lambda: 1.0
+            )()
 
-            max_phys_size_x = max(max_phys_size_x, ome_meta.getPixelsPhysicalSizeX(series).value())
-            max_phys_size_y = max(max_phys_size_y, ome_meta.getPixelsPhysicalSizeY(series).value())
-            max_phys_size_z = max(max_phys_size_z, ome_meta.getPixelsPhysicalSizeZ(series).value()
-                                  if phys_size_z else z_interval)
+            max_phys_size_x = max(
+                max_phys_size_x, ome_meta.getPixelsPhysicalSizeX(series).value()
+            )
+            max_phys_size_y = max(
+                max_phys_size_y, ome_meta.getPixelsPhysicalSizeY(series).value()
+            )
+            max_phys_size_z = max(
+                max_phys_size_z,
+                ome_meta.getPixelsPhysicalSizeZ(series).value()
+                if phys_size_z
+                else z_interval,
+            )
 
             stage_coordinates_x.append(current_position_x)
             stage_coordinates_y.append(current_position_y)

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -27,6 +27,153 @@ from ._loci import (
 )
 
 
+class ImageMetadata(object):
+    """A class to store metadata information from an image.
+
+    This class stores metadata information extracted from an image file, such as image dimensions,
+    pixel dimensions, and calibration units. It provides a method to convert the attributes to a
+    dictionary and a string representation of the object.
+
+    Attributes
+    ----------
+    unit_width : float or None
+        Physical width of a pixel in the given unit.
+    unit_height : float or None
+        Physical height of a pixel in the given unit.
+    unit_depth : float or None
+        Physical depth of a voxel in the given unit.
+    pixel_width : int or None
+        Width of the image in pixels.
+    pixel_height : int or None
+        Height of the image in pixels.
+    slice_count : int or None
+        Number of Z-slices in the image.
+    channel_count : int or None
+        Number of channels in the image.
+    timepoints_count : int or None
+        Number of timepoints in the image.
+    dimension_order : str or None
+        Order of dimensions (e.g., "XYZCT").
+    pixel_type : str or None
+        Data type of the pixel values (e.g., "uint16").
+
+    Examples
+    --------
+    >>> metadata = ImageMetadata(
+    ...     unit_width=0.1,
+    ...     unit_height=0.1
+    ...     )
+    >>> print(metadata)
+    <ImageMetadata(unit_width=0.1, unit_height=0.1, ...)>
+    """
+
+    def __init__(
+        self,
+        unit_width=None,
+        unit_height=None,
+        unit_depth=None,
+        pixel_width=None,
+        pixel_height=None,
+        slice_count=None,
+        channel_count=None,
+        timepoints_count=None,
+        dimension_order=None,
+        pixel_type=None,
+    ):
+        self.unit_width = unit_width
+        self.unit_height = unit_height
+        self.unit_depth = unit_depth
+        self.pixel_width = pixel_width
+        self.pixel_height = pixel_height
+        self.slice_count = slice_count
+        self.channel_count = channel_count
+        self.timepoints_count = timepoints_count
+        self.dimension_order = dimension_order
+        self.pixel_type = pixel_type
+
+    def to_dict(self):
+        """Convert the object attributes to a dictionary.
+
+        Returns
+        -------
+        dict
+            A dictionary representation of the object attributes.
+        """
+        return self.__dict__
+
+    def __repr__(self):
+        """Return a string representation of the object."""
+        return "<ImageMetadata({})>".format(
+            ", ".join("{}={}".format(k, v) for k, v in self.__dict__.items())
+        )
+
+
+class StageMetadata:
+    """A class to store stage coordinates and calibration metadata for a set of images.
+
+    Attributes
+    ----------
+    dimensions : int
+        Number of dimensions (2D or 3D).
+    stage_coordinates_x : list of float
+        Absolute stage x-coordinates.
+    stage_coordinates_y : list of float
+        Absolute stage y-coordinates.
+    stage_coordinates_z : list of float
+        Absolute stage z-coordinates.
+    relative_coordinates_x : list of float
+        Relative stage x-coordinates in pixels.
+    relative_coordinates_y : list of float
+        Relative stage y-coordinates in pixels.
+    relative_coordinates_z : list of float
+        Relative stage z-coordinates in pixels.
+    image_calibration : list of float
+        Calibration values for x, y, and z in unit/px.
+    calibration_unit : str
+        Unit used for image calibration.
+    image_dimensions_czt : list of int
+        Number of images in dimensions (channels, z-slices, timepoints).
+    series_names : list of str
+        Names of all series in the image files.
+    max_size : list of float
+        Maximum physical size (x/y/z) across all files.
+    """
+
+    def __init__(
+        self,
+        dimensions=2,
+        stage_coordinates_x=None,
+        stage_coordinates_y=None,
+        stage_coordinates_z=None,
+        relative_coordinates_x=None,
+        relative_coordinates_y=None,
+        relative_coordinates_z=None,
+        image_calibration=None,
+        calibration_unit="unknown",
+        image_dimensions_czt=None,
+        series_names=None,
+        max_size=None,
+    ):
+        self.dimensions = dimensions
+        self.stage_coordinates_x = stage_coordinates_x or []
+        self.stage_coordinates_y = stage_coordinates_y or []
+        self.stage_coordinates_z = stage_coordinates_z or []
+        self.relative_coordinates_x = relative_coordinates_x or []
+        self.relative_coordinates_y = relative_coordinates_y or []
+        self.relative_coordinates_z = relative_coordinates_z or []
+        self.image_calibration = image_calibration or [1.0, 1.0, 1.0]
+        self.calibration_unit = calibration_unit or "unknown"
+        self.image_dimensions_czt = image_dimensions_czt or [1, 1, 1]
+        self.series_names = series_names or []
+        self.max_size = max_size or [1.0, 1.0, 1.0]
+
+    def __repr__(self):
+        """Return a string representation of the object."""
+        return "<StageMetadata(dimensions={}, calibration_unit='{}', ...)>".format(
+            self.dimensions, self.calibration_unit
+        )
+
+
 def import_image(
     filename,
     color_mode="color",

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -103,12 +103,6 @@ class ImageMetadata(object):
         """
         return self.__dict__
 
-    def __repr__(self):
-        """Return a string representation of the object."""
-        return "<ImageMetadata({})>".format(
-            ", ".join("{}={}".format(k, v) for k, v in self.__dict__.items())
-        )
-
 
 class StageMetadata(object):
     """A class to store stage coordinates and calibration metadata for a set of images.

--- a/src/imcflibs/imagej/prefs.py
+++ b/src/imcflibs/imagej/prefs.py
@@ -37,8 +37,8 @@ def set_default_ij_options():
     # Set foreground color to be white and background black
     IJ.run("Colors...", "foreground=white background=black selection=red")
 
-    # Set black background for binary images and set pad edges to false to prevent eroding from image edge
-    IJ.run("Options...", "black ")
+    # Set black background for binary images and set pad edges to true to prevent eroding from image edge
+    IJ.run("Options...", "iterations=1 count=1 black pad")
 
     # Set default saving format to .txt files
     IJ.run("Input/Output...", "file=.txt save_column save_row")

--- a/tests/interactive-imagej/bioformats/metadata/test_metadata.md
+++ b/tests/interactive-imagej/bioformats/metadata/test_metadata.md
@@ -5,17 +5,20 @@ Copy the following code to a Fiji that has the release `python-imcflibs-1.5.0.ja
 Add the source folder and the names of the files under the corresponding lines, and run the script. If the metadata is printed in Fiji output, the methods are working as intended
 
 ```
+# @ File (label="IMCF testdata location", style="directory") IMCF_TESTDATA
+
 import os
+from imcflibs.pathtools import join2
 from imcflibs.imagej import bioformats
 from ij import IJ
 
 # Testing for the metadata retrieval through Bioformats
 
 # Add directory path here that contains the files you wish to test for
-path = r"U:\\VAMP\\rohang0000\\stage_test"
-file_path_1 = os.path.join(path, "DON_25922_20250201_25922_2_01.vsi")
-file_path_2 = os.path.join(path, "DON_25922_20250201_25922_2_02.vsi")
-file_path_3 = os.path.join(path, "DON_25922_20250201_25922_2_03.vsi")
+
+file_path_1 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_01.vsi")
+file_path_2 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_02.vsi")
+file_path_3 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_03.vsi")
 
 metadata = bioformats.get_metadata_from_file(file_path_1)
 print(metadata.unit_width)

--- a/tests/interactive-imagej/bioformats/metadata/test_metadata.md
+++ b/tests/interactive-imagej/bioformats/metadata/test_metadata.md
@@ -16,9 +16,9 @@ from ij import IJ
 
 # Add directory path here that contains the files you wish to test for
 
-file_path_1 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_01.vsi")
-file_path_2 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_02.vsi")
-file_path_3 = join2(IMCF_TESTDATA, "bioformats/DON_25922_20250201_25922_2_03.vsi")
+file_path_1 = join2(IMCF_TESTDATA, "bioformats-multiposition/DON_25922_20250201_25922_2_01.vsi")
+file_path_2 = join2(IMCF_TESTDATA, "bioformats-multiposition/DON_25922_20250201_25922_2_02.vsi")
+file_path_3 = join2(IMCF_TESTDATA, "bioformats-multiposition/DON_25922_20250201_25922_2_03.vsi")
 
 metadata = bioformats.get_metadata_from_file(file_path_1)
 print(metadata.unit_width)

--- a/tests/interactive-imagej/bioformats/metadata/test_metadata.md
+++ b/tests/interactive-imagej/bioformats/metadata/test_metadata.md
@@ -1,0 +1,34 @@
+Following is a testing script for the retrieval of metadata methods in imcflibs.imagej.bioformats.
+
+Copy the following code to a Fiji that has the release `python-imcflibs-1.5.0.jar` in the /jars directory.
+
+Add the source folder and the names of the files under the corresponding lines, and run the script. If the metadata is printed in Fiji output, the methods are working as intended
+
+```
+import os
+from imcflibs.imagej import bioformats
+from ij import IJ
+
+# Testing for the metadata retrieval through Bioformats
+
+# Add directory path here that contains the files you wish to test for
+path = r"U:\\VAMP\\rohang0000\\stage_test"
+file_path_1 = os.path.join(path, "DON_25922_20250201_25922_2_01.vsi")
+file_path_2 = os.path.join(path, "DON_25922_20250201_25922_2_02.vsi")
+file_path_3 = os.path.join(path, "DON_25922_20250201_25922_2_03.vsi")
+
+metadata = bioformats.get_metadata_from_file(file_path_1)
+print(metadata.unit_width)
+print(metadata.unit)
+print(metadata.channel_count)
+
+# Stage metadata and coordinates test for a list of vsi files
+fnames = [file_path_1, file_path_2, file_path_3]
+
+metadata_stage = bioformats.get_stage_coords(fnames)
+
+print(metadata_stage.image_calibration)
+print(metadata_stage.stage_coordinates_x)
+print(metadata_stage.stage_coordinates_y)
+print(metadata_stage.stage_coordinates_z)
+```


### PR DESCRIPTION
Metadata and stage coordinates are now returned as their own class, making it easier to access attributes, such as height, width & calibration.

Small change in `imagej.prefs.set_default_ij_options`: the default option is to tick the pad edge box now, not unticked. 