### PR TITLE
Fix issue with CZI autostitch options

### DIFF
--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -405,7 +405,7 @@ def get_series_info_from_ome_metadata(path_to_file, skip_labels=False):
 
     reader, ome_meta = get_reader(path_to_file, skip_labels)
     series_count = reader.getSeriesCount()
-    if skip_labels:
+    if not skip_labels:
         # If we are not skipping labels, return the full range
         return series_count, range(series_count)
 

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -374,7 +374,7 @@ def get_reader(path_to_file, setFlattenedResolutions=False):
     m.setBoolean(ZeissCZIReader.ALLOW_AUTOSTITCHING_KEY, False)
     reader.setMetadataOptions(m)
     reader.setId(str(path_to_file))
-    return reader
+    return reader, ome_meta
 
 
 def get_series_info_from_ome_metadata(path_to_file, skip_labels=False):
@@ -403,7 +403,7 @@ def get_series_info_from_ome_metadata(path_to_file, skip_labels=False):
     >>> count, indices = get_series_info_from_ome_metadata("image.nd2", skip_labels=True)
     """
 
-    reader = get_reader(path_to_file, skip_labels)
+    reader, ome_meta = get_reader(path_to_file, skip_labels)
     series_count = reader.getSeriesCount()
     if skip_labels:
         # If we are not skipping labels, return the full range
@@ -464,7 +464,7 @@ def get_metadata_from_file(path_to_image):
         An instance of `imcflibs.imagej.bioformats.ImageMetadata` containing the extracted metadata.
     """
 
-    reader = get_reader(path_to_image)
+    reader, ome_meta = get_reader(path_to_image)
 
     metadata = ImageMetadata(
         unit_width=ome_meta.getPixelsPhysicalSizeX(0).value(),
@@ -515,8 +515,8 @@ def get_stage_coords(filenames):
     max_phys_size_y = 0.0
     max_phys_size_z = 0.0
 
-    for counter, path_to_image in enumerate(filenames):
-        reader = get_reader(path_to_image)
+    for counter, image in enumerate(filenames):
+        reader, ome_meta = get_reader(image)
         series_count = reader.getSeriesCount()
 
         # Process only the first image to get values not dependent on series

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -352,6 +352,31 @@ def export_using_orig_name(imp, path, orig_name, tag, suffix, overwrite=False):
     return out_file
 
 
+def get_reader(path_to_file, setFlattenedResolutions=False):
+    """Get a Bio-Formats ImageReader for the specified file.
+
+    Parameters
+    ----------
+    path_to_file : str
+        The full path to the image file.
+    setFlattenedResolutions : bool, optional
+        Whether to flatten resolutions in the ImageReader (default: False).
+
+    Returns
+    -------
+    ImageReader
+        A configured ImageReader instance for the specified file.
+    """
+    reader = ImageReader()
+    ome_meta = MetadataTools.createOMEXMLMetadata()
+    reader.setMetadataStore(ome_meta)
+    m = DynamicMetadataOptions()
+    m.setBoolean(ZeissCZIReader.ALLOW_AUTOSTITCHING_KEY, False)
+    reader.setMetadataOptions(m)
+    reader.setId(str(path_to_file))
+    return reader
+
+
 def get_series_info_from_ome_metadata(path_to_file, skip_labels=False):
     """Get the Bio-Formats series information from a file on disk.
 
@@ -378,44 +403,31 @@ def get_series_info_from_ome_metadata(path_to_file, skip_labels=False):
     >>> count, indices = get_series_info_from_ome_metadata("image.nd2", skip_labels=True)
     """
 
-    if not skip_labels:
-        reader = ImageReader()
-        reader.setFlattenedResolutions(False)
-        ome_meta = MetadataTools.createOMEXMLMetadata()
-        reader.setMetadataStore(ome_meta)
-        reader.setId(path_to_file)
-        series_count = reader.getSeriesCount()
-
-        reader.close()
+    reader = get_reader(path_to_file, skip_labels)
+    series_count = reader.getSeriesCount()
+    if skip_labels:
+        # If we are not skipping labels, return the full range
         return series_count, range(series_count)
 
-    else:
-        reader = ImageReader()
-        # reader.setFlattenedResolutions(True)
-        ome_meta = MetadataTools.createOMEXMLMetadata()
-        reader.setMetadataStore(ome_meta)
-        reader.setId(path_to_file)
-        series_count = reader.getSeriesCount()
+    series_ids = []
+    series_names = []
+    x = 0
+    y = 0
+    for i in range(series_count):
+        reader.setSeries(i)
 
-        series_ids = []
-        series_names = []
-        x = 0
-        y = 0
-        for i in range(series_count):
-            reader.setSeries(i)
+        if reader.getSizeX() > x and reader.getSizeY() > y:
+            name = ome_meta.getImageName(i)
 
-            if reader.getSizeX() > x and reader.getSizeY() > y:
-                name = ome_meta.getImageName(i)
+            if name not in ["label image", "macro image"]:
+                series_ids.append(i)
+                series_names.append(name)
 
-                if name not in ["label image", "macro image"]:
-                    series_ids.append(i)
-                    series_names.append(name)
+        x = reader.getSizeX()
+        y = reader.getSizeY()
 
-            x = reader.getSizeX()
-            y = reader.getSizeY()
-
-        print(series_names)
-        return len(series_ids), series_ids
+    print(series_names)
+    return len(series_ids), series_ids
 
 
 def write_bf_memoryfile(path_to_file):
@@ -452,10 +464,7 @@ def get_metadata_from_file(path_to_image):
         An instance of `imcflibs.imagej.bioformats.ImageMetadata` containing the extracted metadata.
     """
 
-    reader = ImageReader()
-    ome_meta = MetadataTools.createOMEXMLMetadata()
-    reader.setMetadataStore(ome_meta)
-    reader.setId(str(path_to_image))
+    reader = get_reader(path_to_image)
 
     metadata = ImageMetadata(
         unit_width=ome_meta.getPixelsPhysicalSizeX(0).value(),
@@ -506,15 +515,8 @@ def get_stage_coords(filenames):
     max_phys_size_y = 0.0
     max_phys_size_z = 0.0
 
-    for counter, image in enumerate(filenames):
-        reader = ImageReader()
-        reader.setFlattenedResolutions(False)
-        ome_meta = MetadataTools.createOMEXMLMetadata()
-        reader.setMetadataStore(ome_meta)
-        m = DynamicMetadataOptions()
-        m.setBoolean(ZeissCZIReader.ALLOW_AUTOSTITCHING_KEY, False)
-        reader.setMetadataOptions(m)
-        reader.setId(str(image))
+    for counter, path_to_image in enumerate(filenames):
+        reader = get_reader(path_to_image)
         series_count = reader.getSeriesCount()
 
         # Process only the first image to get values not dependent on series

--- a/src/imcflibs/imagej/bioformats.py
+++ b/src/imcflibs/imagej/bioformats.py
@@ -511,6 +511,9 @@ def get_stage_coords(filenames):
         reader.setFlattenedResolutions(False)
         ome_meta = MetadataTools.createOMEXMLMetadata()
         reader.setMetadataStore(ome_meta)
+        m = DynamicMetadataOptions()
+        m.setBoolean(ZeissCZIReader.ALLOW_AUTOSTITCHING_KEY, False)
+        reader.setMetadataOptions(m)
         reader.setId(str(image))
         series_count = reader.getSeriesCount()
 


### PR DESCRIPTION
CZI files are still opened with the `AutoStitch` option enabled, even if **_off_** in the Bio-Formats configuration. 

This PR disables this option in all cases.