### PR TITLE
Add method to save Fiji script parameters, and add example to opening an image

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -105,13 +105,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "imcf-fiji-mocks"
-version = "0.12.0"
+version = "0.13.0"
 description = "Mocks collection for Fiji-Python. Zero functional code."
 optional = false
 python-versions = ">=2.7"
 files = [
-    {file = "imcf_fiji_mocks-0.12.0-py2.py3-none-any.whl", hash = "sha256:00e746e1ecdfb9743ef0e6886b9234663aaf3c762a77c162c54bb02d95a53dac"},
-    {file = "imcf_fiji_mocks-0.12.0.tar.gz", hash = "sha256:4e55836503fee0564aa7fbdd8c019504d1d3f4e9c06b1cd269242af2da3d7450"},
+    {file = "imcf_fiji_mocks-0.13.0-py2.py3-none-any.whl", hash = "sha256:cb6be2b4af480a9340d182c2bccff78f996c0048abbf05380e214a91a2f89bf2"},
+    {file = "imcf_fiji_mocks-0.13.0.tar.gz", hash = "sha256:c29f2dc82a0d4e94963a9f7a455f17012ee37aa8eda4d1c9e9565496df50b063"},
 ]
 
 [[package]]
@@ -271,4 +271,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "e107ad5e21140ce701c48b7f84654dc7dce045ca05550a06b6dc16f8f19136a7"
+content-hash = "60258d00dfaba337eff7fb89a463d281320df110050c0360a3e87397a1ea3398"

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,13 +105,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "imcf-fiji-mocks"
-version = "0.10.0"
+version = "0.12.0"
 description = "Mocks collection for Fiji-Python. Zero functional code."
 optional = false
 python-versions = ">=2.7"
 files = [
-    {file = "imcf_fiji_mocks-0.10.0-py2.py3-none-any.whl", hash = "sha256:476927d82fa0e93b0b0b738f82cab60e180cf0da5b3dd09dc6a5336b08e18d2d"},
-    {file = "imcf_fiji_mocks-0.10.0.tar.gz", hash = "sha256:d1f3302031cad5f1d15388bf337025bbfb59037a04e79a102de59093e643a5f5"},
+    {file = "imcf_fiji_mocks-0.12.0-py2.py3-none-any.whl", hash = "sha256:00e746e1ecdfb9743ef0e6886b9234663aaf3c762a77c162c54bb02d95a53dac"},
+    {file = "imcf_fiji_mocks-0.12.0.tar.gz", hash = "sha256:4e55836503fee0564aa7fbdd8c019504d1d3f4e9c06b1cd269242af2da3d7450"},
 ]
 
 [[package]]
@@ -271,4 +271,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "6b4a1828157bbddc15f61de0427a3d7970a61da1750f2cbf9e160f1b7546d7c9"
+content-hash = "e107ad5e21140ce701c48b7f84654dc7dce045ca05550a06b6dc16f8f19136a7"

--- a/poetry.lock.md
+++ b/poetry.lock.md
@@ -12,5 +12,14 @@ rather the Poetry wrapper script has to be used like this:
 scripts/run-poetry.sh lock --no-update
 ```
 
+Sometimes poetry is refusing to update its cache for unknown reasons, resulting
+in a message saying `doesn't match any versions, version solving failed` or
+similar. To solve this, fully clear the cache and re-run the `lock` command:
+
+```bash
+scripts/run-poetry.sh cache clear --all -- PyPI
+scripts/run-poetry.sh lock --no-update
+```
+
 [1]: https://pypi.org/project/imcf-fiji-mocks
 [2]: https://python-poetry.org/docs/basic-usage/#committing-your-poetrylock-file-to-version-control

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ version = "0.0.0"
 # - or: python = ">=3.10"
 
 [tool.poetry.dependencies]
-imcf-fiji-mocks = ">=0.10.0"
+imcf-fiji-mocks = ">=0.12.0"
 python = ">=2.7"
 python-micrometa = "^15.2.2"
 sjlogging = ">=0.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ version = "0.0.0"
 # - or: python = ">=3.10"
 
 [tool.poetry.dependencies]
-imcf-fiji-mocks = ">=0.12.0"
+imcf-fiji-mocks = ">=0.13.0"
 python = ">=2.7"
 python-micrometa = "^15.2.2"
 sjlogging = ">=0.5.2"

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -7,7 +7,6 @@ import smtplib
 import subprocess
 import sys
 import time
-from org.scijava.script import ScriptModule
 
 from ij import IJ  # pylint: disable-msg=import-error
 from ij.plugin import Duplicator, ImageCalculator, StackWriter

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -728,7 +728,7 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     # Get the ScriptModule object from globals made by Fiji
     module = globals().get("org.scijava.script.ScriptModule")
     if module is None:
-        print("No ScriptModule found — skipping saving script parameters.")
+        print("No ScriptModule found - skipping saving script parameters.")
         return
 
     destination = str(destination)

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -719,7 +719,7 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     Notes
     -----
     This function records all input parameters defined in the Fiji script header
-    (e.g. #@ String) to a text file.
+    (e.g. `#@ String`) to a text file.
 
     The following parameters are excluded:
     - Parameters explicitly declared with `style="password"` are ignored.

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -7,6 +7,7 @@ import smtplib
 import subprocess
 import sys
 import time
+from org.scijava.script import ScriptModule
 
 from ij import IJ  # pylint: disable-msg=import-error
 from ij.plugin import Duplicator, ImageCalculator, StackWriter
@@ -701,3 +702,35 @@ def run_imarisconvert(file_path):
         IJ.log("Conversion to .ims is finished.")
     else:
         IJ.log("Conversion failed with error code: %d" % result)
+    
+
+def save_script_parameters(destination, save_file_name="script_parameters.txt"):
+    """Save all Fiji script parameters to a text file.
+
+    Parameters
+    ----------
+    destination : str
+        Directory where the script parameters file will be saved.
+    save_file_name : str, optional
+        Name of the script parameters file, by default "script_parameters.txt".
+    """
+    # Get the ScriptModule object from globals made by Fiji
+    module = globals().get("org.scijava.script.ScriptModule")
+    if module is None:
+        print("No ScriptModule found- skipping saving script parameters.")
+        return
+
+    # Retrieve the input parameters from the scijava module
+    inputs = module.getInputs()
+    destination = str(destination)
+    out_path = os.path.join(destination, save_file_name)
+    
+    # Write the parameters to output file
+    with open(out_path, "w") as f:
+        for key in inputs.keySet():
+            val = inputs.get(key)
+            f.write("%s: %s\n" % (key, str(val)))
+
+    print("Saved script parameters to: %s" % out_path)
+
+

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -728,7 +728,7 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     # Get the ScriptModule object from globals made by Fiji
     module = globals().get("org.scijava.script.ScriptModule")
     if module is None:
-        print("No ScriptModule found - skipping saving script parameters.")
+        IJ.log("No ScriptModule found - skipping saving script parameters.")
         return
 
     destination = str(destination)

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -16,6 +16,9 @@ from ..log import LOG as log
 from . import bioformats as bf
 from . import prefs
 
+from org.scijava.widget import WidgetStyle
+from org.scijava.widget import TextWidget
+
 
 def show_status(msg):
     """Update the ImageJ status bar and issue a log message.
@@ -746,9 +749,8 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
             if any(skip in key.upper() for skip in skip_keys):
                 continue
 
-            # Skip if parameter is declared with style="password"
-            style = item.getWidgetStyle()
-            if style is not None and style.lower() == "password":
+            # Skip if parameter is declared with password style
+            if WidgetStyle.isStyle(item, TextWidget.PASSWORD_STYLE):
                 continue
 
             if inputs.containsKey(key):

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -726,8 +726,11 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     out_path = os.path.join(destination, save_file_name)
     
     # Write the parameters to output file
+    skip_keys = ["PASSWORD", "USERNAME", "SJLOG", "COMMAND", "RM"]
     with open(out_path, "w") as f:
         for key in inputs.keySet():
+            if any(s in key.upper() for s in skip_keys):
+                continue
             val = inputs.get(key)
             f.write("%s: %s\n" % (key, str(val)))
 

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -731,11 +731,11 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     destination = str(destination)
     out_path = os.path.join(destination, save_file_name)
 
-    # Access script metadata and parameter map
+    # Access script metadata and inputs
     script_info = module.getInfo()
     inputs = module.getInputs()
 
-    # Keys to skip explicitly (case-insensitive match)
+    # Keys to skip explicitly
     skip_keys = ["USERNAME", "SJLOG", "COMMAND", "RM"]
 
     with open(out_path, "w") as f:
@@ -751,7 +751,6 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
             if style is not None and style.lower() == "password":
                 continue
 
-            # Write all other parameters
             if inputs.containsKey(key):
                 val = inputs.get(key)
                 f.write("%s: %s\n" % (key, str(val)))

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -702,7 +702,7 @@ def run_imarisconvert(file_path):
         IJ.log("Conversion to .ims is finished.")
     else:
         IJ.log("Conversion failed with error code: %d" % result)
-    
+
 
 def save_script_parameters(destination, save_file_name="script_parameters.txt"):
     """Save all Fiji script parameters to a text file.
@@ -713,9 +713,9 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
         Directory where the script parameters file will be saved.
     save_file_name : str, optional
         Name of the script parameters file, by default "script_parameters.txt".
-    
+
     Notes
-    ----------
+    -----
     This function records all input parameters defined in the Fiji script header
     (e.g. #@ String) to a text file.
 
@@ -758,6 +758,3 @@ def save_script_parameters(destination, save_file_name="script_parameters.txt"):
                 f.write("%s: %s\n" % (key, str(val)))
 
     print("Saved script parameters to: %s" % out_path)
-
-
-

--- a/src/imcflibs/imagej/omerotools.py
+++ b/src/imcflibs/imagej/omerotools.py
@@ -47,6 +47,15 @@ def parse_url(client, omero_str):
     -------
     list(fr.igred.omero.repository.ImageWrapper)
         List of ImageWrappers parsed from the string.
+
+    Examples
+    --------
+    >>> from fr.igred.omero import Client
+    >>> client = Client()
+    >>> OMERO_LINK = "123456"
+    >>> img_wrappers = omerotools.parse_url(client, OMERO_LINK)
+    >>> for wrapper in img_wrappers:
+    >>>    imp = wpr.toImagePlus(client)
     """
     image_ids = []
     dataset_ids = []


### PR DESCRIPTION
Safe way of parsing Fiji script params by ignoring the passwords field automatically.