### PR TITLE
Validate slice count before subtraction

### DIFF
--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -417,7 +417,7 @@ def subtract_images(imp1, imp2):
     """
     ic = ImageCalculator()
     if imp1.getNSlices() != imp2.getNSlices():
-        sys.exit(
+        raise ValueError(
             "Cannot subtract images with different number of slices, "
             "please check your input data."
         )

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -416,7 +416,13 @@ def subtract_images(imp1, imp2):
         The ImagePlus resulting from the subtraction.
     """
     ic = ImageCalculator()
-    subtracted = ic.run("Subtract create", imp1, imp2)
+    if imp1.getNSlices() != imp2.getNSlices():
+        sys.exit(
+            "Cannot subtract images with different number of slices, "
+            "please check your input data."
+        )
+    option = " stack" if imp1.getNSlices() > 1 else ""
+    subtracted = ic.run("Subtract create" + option, imp1, imp2)
 
     return subtracted
 

--- a/src/imcflibs/imagej/misc.py
+++ b/src/imcflibs/imagej/misc.py
@@ -423,6 +423,7 @@ def subtract_images(imp1, imp2):
         )
     option = " stack" if imp1.getNSlices() > 1 else ""
     subtracted = ic.run("Subtract create" + option, imp1, imp2)
+    subtracted.setCalibration(imp1.getCalibration())
 
     return subtracted
 


### PR DESCRIPTION
* Added a check to ensure both images have the same number of slices.
* Exits with an error message if the slice counts differ.
* Adjusted the subtraction operation to handle stack images appropriately.