### PR TITLE
Sanitize input string in `omerotools.parse_url`

### DIFF
--- a/src/imcflibs/imagej/omerotools.py
+++ b/src/imcflibs/imagej/omerotools.py
@@ -57,6 +57,11 @@ def parse_url(client, omero_str):
     >>> for wrapper in img_wrappers:
     >>>    imp = wpr.toImagePlus(client)
     """
+    # Sanitize the string
+    if omero_str is None:
+        return []
+    omero_str = omero_str.strip()
+    
     image_ids = []
     dataset_ids = []
     image_wpr_list = []

--- a/src/imcflibs/imagej/omerotools.py
+++ b/src/imcflibs/imagej/omerotools.py
@@ -57,7 +57,7 @@ def parse_url(client, omero_str):
     >>> for wrapper in img_wrappers:
     >>>    imp = wpr.toImagePlus(client)
     """
-    if omero_str is None or str(omero_str).strip() == "":
+    if not str(omero_str).strip():
         raise ValueError("No OMERO link or image ID provided.")
 
     # Sanitize the string

--- a/src/imcflibs/imagej/omerotools.py
+++ b/src/imcflibs/imagej/omerotools.py
@@ -57,11 +57,12 @@ def parse_url(client, omero_str):
     >>> for wrapper in img_wrappers:
     >>>    imp = wpr.toImagePlus(client)
     """
+    if omero_str is None or str(omero_str).strip() == "":
+        raise ValueError("No OMERO link or image ID provided.")
+
     # Sanitize the string
-    if omero_str is None:
-        return []
     omero_str = omero_str.strip()
-    
+
     image_ids = []
     dataset_ids = []
     image_wpr_list = []


### PR DESCRIPTION
Fixes from #115: the issue of a trailing white space leading to the method crashing, and gracefully raises an error if the input string is empty. 